### PR TITLE
add chance pkg to dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1995,6 +1995,11 @@
         "supports-color": "5.4.0"
       }
     },
+    "chance": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/chance/-/chance-1.0.16.tgz",
+      "integrity": "sha512-2bgDHH5bVfAXH05SPtjqrsASzZ7h90yCuYT2z4mkYpxxYvJXiIydBFzVieVHZx7wLH1Ag2Azaaej2/zA1XUrNQ=="
+    },
     "chardet": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@living-room/client-js": "^0.4.3",
     "@living-room/service-js": "^0.4.3",
+    "chance": "^1.0.16",
     "node-fetch": "^2.1.2",
     "npm-run-all": "^4.1.2",
     "prettier-standard": "^8.0.1",


### PR DESCRIPTION
The chance node package is used in the project but not included in the dependencies.

In `src/util/sensor.js`,
```
1: const Chance = require('chance')
```

This PR adds `chance` to package.json