### PR TITLE
Fix bug in move.js

### DIFF
--- a/src/processes/move.js
+++ b/src/processes/move.js
@@ -10,7 +10,7 @@ module.exports = room => {
     `$name has speed ($dx, $dy)`,
     ({ assertions, retractions }) => {
       assertions.forEach(({ name, dx, dy }) => {
-        if (dx.value + dy.value == 0) {
+        if (dx.value == 0 && dy.value == 0) {
           animalSpeeds.delete(name.word)
         } else {
           animalSpeeds.set(name.word, {


### PR DESCRIPTION
There's a bug in the check that makes sure that we don't update animals location when the speed is 0. The check is that `dx.value + dy.value == 0`. This will discard valid speeds like `(-0.05, 0.05)`. The check should instead be `dx.value == 0 && dy.value == 0`